### PR TITLE
docs: Update thumbprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Resources:
 
       # This is the thumbprint of `token.actions.githubusercontent.com`
       # See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
-      ThumbprintList: [a031c46782e6e6c662c2c87c76da9aa62ccabd8e]
+      ThumbprintList: [6938fd4d98bab03faadb97b34396831e3780aea1]
 
 Outputs:
   GitHubRoleArn:


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

From https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/:

> While renewing GitHub Actions SSL certificates, an unexpected change in the intermediate certificate authority broke workflows using Open ID Connect (OIDC) based deployment to AWS.

See https://github.com/guardian/cdk/pull/1045#issuecomment-1033804225.

Note - we plan to deprecate this action in favour of https://github.com/aws-actions/configure-aws-credentials.